### PR TITLE
!zz dont show up in logs anymore

### DIFF
--- a/blizzbot.py
+++ b/blizzbot.py
@@ -287,7 +287,9 @@ async def on_message_delete(message):
         else:
             embed.add_field(name="Inhalt", value="Inhalt nicht auslesbar", inline=False)
 
-        await channel.send(embed=embed)
+        channelID = message.channel.id
+        if not ((channnelID is IDchannelverificate) and (message.content is "!zz")) 
+            await channel.send(embed=embed)
 
     return
 


### PR DESCRIPTION
• The !zz message in the #freischalten-channel doesn't show up in the #logs-channel anymore.
        ➥ This is done by prevennting the log-message from geting sent, when it was "!zz" and postet in the #freischalten-channel.